### PR TITLE
fix(nuxt): normalize segment catchall pattern before checking for parent

### DIFF
--- a/packages/nuxt/src/pages/utils.ts
+++ b/packages/nuxt/src/pages/utils.ts
@@ -144,7 +144,7 @@ export function generateRoutesFromFiles (files: ScannedFile[], options: Generate
       // ex: parent.vue + parent/child.vue
       const routePath = getRoutePath(tokens, segments[i + 1] !== undefined && segments[i + 1] !== 'index')
       const path = withLeadingSlash(joinURL(route.path, routePath.replace(INDEX_PAGE_RE, '/')))
-      const child = parent.find(parentRoute => parentRoute.name === route.name && parentRoute.path === path)
+      const child = parent.find(parentRoute => parentRoute.name === route.name && parentRoute.path === path.replace('([^/]*)*', '(.*)*'))
 
       if (child && child.children) {
         parent = child.children

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -396,6 +396,28 @@
       "redirect": "mockMeta?.redirect",
     },
   ],
+  "should generate correct routes for nested pages with catch-all": [
+    {
+      "alias": "mockMeta?.alias || []",
+      "children": [
+        {
+          "alias": "mockMeta?.alias || []",
+          "component": "() => import("pages/[...id]/[slug].vue")",
+          "meta": "mockMeta || {}",
+          "name": "mockMeta?.name ?? "id-slug"",
+          "path": "mockMeta?.path ?? ":slug()"",
+          "props": "mockMeta?.props ?? false",
+          "redirect": "mockMeta?.redirect",
+        },
+      ],
+      "component": "() => import("pages/[...id].vue")",
+      "meta": "mockMeta || {}",
+      "name": "mockMeta?.name ?? "id"",
+      "path": "mockMeta?.path ?? "/:id(.*)*"",
+      "props": "mockMeta?.props ?? false",
+      "redirect": "mockMeta?.redirect",
+    },
+  ],
   "should generate correct routes for parent/child": [
     {
       "alias": "mockMeta?.alias || []",

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-disabled.test.ts.snap
@@ -154,6 +154,17 @@
     },
     {
       "alias": "mockMeta?.alias || []",
+      "children": [
+        {
+          "alias": "mockMeta?.alias || []",
+          "component": "() => import("pages/[...slug]/[foo].vue")",
+          "meta": "mockMeta || {}",
+          "name": "mockMeta?.name ?? "slug-foo"",
+          "path": "mockMeta?.path ?? ":foo()"",
+          "props": "mockMeta?.props ?? false",
+          "redirect": "mockMeta?.redirect",
+        },
+      ],
       "component": "() => import("pages/[...slug].vue")",
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? "slug"",
@@ -392,28 +403,6 @@
       "meta": "mockMeta || {}",
       "name": "mockMeta?.name ?? undefined",
       "path": "mockMeta?.path ?? "/page1"",
-      "props": "mockMeta?.props ?? false",
-      "redirect": "mockMeta?.redirect",
-    },
-  ],
-  "should generate correct routes for nested pages with catch-all": [
-    {
-      "alias": "mockMeta?.alias || []",
-      "children": [
-        {
-          "alias": "mockMeta?.alias || []",
-          "component": "() => import("pages/[...id]/[slug].vue")",
-          "meta": "mockMeta || {}",
-          "name": "mockMeta?.name ?? "id-slug"",
-          "path": "mockMeta?.path ?? ":slug()"",
-          "props": "mockMeta?.props ?? false",
-          "redirect": "mockMeta?.redirect",
-        },
-      ],
-      "component": "() => import("pages/[...id].vue")",
-      "meta": "mockMeta || {}",
-      "name": "mockMeta?.name ?? "id"",
-      "path": "mockMeta?.path ?? "/:id(.*)*"",
       "props": "mockMeta?.props ?? false",
       "redirect": "mockMeta?.redirect",
     },

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -104,6 +104,13 @@
       "path": ""/"",
     },
     {
+      "children": [
+        {
+          "component": "() => import("pages/[...slug]/[foo].vue")",
+          "name": ""slug-foo"",
+          "path": "":foo()"",
+        },
+      ],
       "component": "() => import("pages/[...slug].vue")",
       "name": ""slug"",
       "path": ""/:slug(.*)*"",
@@ -245,20 +252,6 @@
       "component": "() => import("pages/page1.vue")",
       "name": "mockMeta?.name",
       "path": ""/page1"",
-    },
-  ],
-  "should generate correct routes for nested pages with catch-all": [
-    {
-      "children": [
-        {
-          "component": "() => import("pages/[...id]/[slug].vue")",
-          "name": ""id-slug"",
-          "path": "":slug()"",
-        },
-      ],
-      "component": "() => import("pages/[...id].vue")",
-      "name": ""id"",
-      "path": ""/:id(.*)*"",
     },
   ],
   "should generate correct routes for parent/child": [

--- a/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
+++ b/packages/nuxt/test/__snapshots__/pages-override-meta-enabled.test.ts.snap
@@ -247,6 +247,20 @@
       "path": ""/page1"",
     },
   ],
+  "should generate correct routes for nested pages with catch-all": [
+    {
+      "children": [
+        {
+          "component": "() => import("pages/[...id]/[slug].vue")",
+          "name": ""id-slug"",
+          "path": "":slug()"",
+        },
+      ],
+      "component": "() => import("pages/[...id].vue")",
+      "name": ""id"",
+      "path": ""/:id(.*)*"",
+    },
+  ],
   "should generate correct routes for parent/child": [
     {
       "children": [

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -263,7 +263,7 @@ describe('pages:generateRoutesFromFiles', () => {
     },
     {
       description: 'should generate correct catch-all route',
-      files: [{ path: `${pagesDir}/[...slug].vue` }, { path: `${pagesDir}/index.vue` }],
+      files: [{ path: `${pagesDir}/[...slug].vue` }, { path: `${pagesDir}/index.vue` }, { path: `${pagesDir}/[...slug]/[id].vue` }],
       output: [
         {
           name: 'index',
@@ -275,26 +275,13 @@ describe('pages:generateRoutesFromFiles', () => {
           name: 'slug',
           path: '/:slug(.*)*',
           file: `${pagesDir}/[...slug].vue`,
-          children: [],
-        },
-      ],
-    },
-    {
-      description: 'should generate correct routes for nested pages with catch-all',
-      files: [{ path: `${pagesDir}/[...id].vue` }, { path: `${pagesDir}/[...id]/[slug].vue` }],
-      output: [
-        {
-          name: 'id',
-          path: '/:id(.*)*',
-          file: `${pagesDir}/[...id].vue`,
           children: [
             {
-              name: 'id-slug',
-              path: ':slug()',
-              file: `${pagesDir}/[...id]/[slug].vue`,
+              name: 'slug-id',
+              path: ':id()',
+              file: `${pagesDir}/[...slug]/[id].vue`,
               children: [],
-            },
-          ],
+            }],
         },
       ],
     },

--- a/packages/nuxt/test/pages.test.ts
+++ b/packages/nuxt/test/pages.test.ts
@@ -280,6 +280,25 @@ describe('pages:generateRoutesFromFiles', () => {
       ],
     },
     {
+      description: 'should generate correct routes for nested pages with catch-all',
+      files: [{ path: `${pagesDir}/[...id].vue` }, { path: `${pagesDir}/[...id]/[slug].vue` }],
+      output: [
+        {
+          name: 'id',
+          path: '/:id(.*)*',
+          file: `${pagesDir}/[...id].vue`,
+          children: [
+            {
+              name: 'id-slug',
+              path: ':slug()',
+              file: `${pagesDir}/[...id]/[slug].vue`,
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+    {
       description: 'should throw unfinished param error for dynamic route',
       files: [{ path: `${pagesDir}/[slug.vue` }],
       error: 'Unfinished param "slug"',


### PR DESCRIPTION
### 🔗 Linked issue

resolves #32365
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
When a catch-all route is the last segment, it uses the greedy regexp (#31528). However, if it is used in middle of a path, it uses a more performant regexp (see #31450).

This change normalizes segment paths to the greedy regexp during parent checks to handle cases where both might be present (eg. if`[...id].vue` and `[...id]/[slug].vue` are pages) so that child routes are correctly nested.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
